### PR TITLE
Update spec info to point to Media WG

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Contributions to this repository are intended to become part of Recommendation-track documents
 governed by the [W3C Patent Policy](http://www.w3.org/Consortium/Patent-Policy-20040205/) and
-[Document License](http://www.w3.org/Consortium/Legal/copyright-documents). To contribute, you must
+[Software and Document License](http://www.w3.org/Consortium/Legal/copyright-software). To contribute, you must
 either participate in the relevant W3C Working Group or make a non-member patent licensing
  commitment.
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,2 +1,2 @@
 All documents in this Repository are licensed by contributors under the [W3C
-Software and Document License](https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document).
+Software and Document License](http://www.w3.org/Consortium/Legal/copyright-software).

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,2 +1,2 @@
-All documents in this Repository are licensed by contributors under the [W3C Document
-License](http://www.w3.org/Consortium/Legal/copyright-documents).
+All documents in this Repository are licensed by contributors under the [W3C
+Software and Document License](https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document).

--- a/explainer.md
+++ b/explainer.md
@@ -2,7 +2,7 @@
 
 This is the explainer for the Media Capabilities API. The document explains the goals and non-goals of the API and in general helps understand the thought process behind the API. The API shape in the document is mostly for information and might not be final.
 
-This document is a bit more dense that some readers might want. A quick one-pager can be found in the [README.md](https://github.com/WICG/media-capabilities/blob/master/README.md) file.
+This document is a bit more dense that some readers might want. A quick one-pager can be found in the [README.md](https://github.com/w3c/media-capabilities/blob/master/README.md) file.
 
 # Objective
 

--- a/index.bs
+++ b/index.bs
@@ -1,11 +1,11 @@
 <pre class='metadata'>
 Title: Media Capabilities
-Repository: wicg/media-capabilities
-Status: CG-DRAFT
-ED: https://wicg.github.io/media-capabilities/
+Repository: w3c/media-capabilities
+Status: ED
+ED: https://w3c.github.io/media-capabilities/
 Shortname: media-capabilities
 Level: 1
-Group: wicg
+Group: mediawg
 Editor: Mounir Lamouri, w3cid 45389, Google Inc. https://google.com/
 
 Abstract: This specification intends to provide APIs to allow websites to make
@@ -14,9 +14,9 @@ Abstract: will expose information about the decoding and encoding capabilities
 Abstract: for a given format but also output capabilities to find the best match
 Abstract: based on the device's display.
 
-!Participate: <a href='https://github.com/wicg/media-capabilities'>Git Repository.</a>
-!Participate: <a href='https://github.com/wicg/media-capabilities/issues/new'>File an issue.</a>
-!Version History: <a href='https://github.com/wicg/media-capabilities/commits'>https://github.com/wicg/media-capabilities/commits</a>
+!Participate: <a href='https://github.com/w3c/media-capabilities'>Git Repository.</a>
+!Participate: <a href='https://github.com/w3c/media-capabilities/issues/new'>File an issue.</a>
+!Version History: <a href='https://github.com/w3c/media-capabilities/commits'>https://github.com/w3c/media-capabilities/commits</a>
 </pre>
 
 <pre class='anchors'>
@@ -98,17 +98,6 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
 
 spec: workers; urlPrefix: https://www.w3.org/TR/workers/#
     type: interface; text: WorkerGlobalScope; url: the-workerglobalscope-common-interface
-</pre>
-
-<pre class='biblio'>
-{
-    "media-playback-quality": {
-        "href": "https://wicg.github.io/media-playback-quality/",
-        "title": "Media Playback Quality Specification",
-        "status": "CG-DRAFT",
-        "publisher": "WICG"
-    }
-}
 </pre>
 
 <section class='non-normative'>
@@ -1001,7 +990,7 @@ spec: workers; urlPrefix: https://www.w3.org/TR/workers/#
 
     <p class='issue'>
       Part of this section is 🐵 patching of the CSSOM View Module. <a
-      href='https://github.com/WICG/media-capabilities/issues/4'>Issue #4</a>
+      href='https://github.com/w3c/media-capabilities/issues/4'>Issue #4</a>
       is tracking merging the changes. This partial interface requires the
       {{Screen}} interface to become an {{EventTarget}}.
     </p>

--- a/security-privacy-questionnaire.md
+++ b/security-privacy-questionnaire.md
@@ -84,7 +84,7 @@ their browser information.
 **Does this specification have a "Security Considerations" and
 "Privacy Considerations" section?**
 
-[Yes](https://wicg.github.io/media-capabilities/#security-privacy-considerations).
+[Yes](https://w3c.github.io/media-capabilities/#security-privacy-considerations).
 
 **Does this specification allow downgrading default security characteristics?**
 

--- a/w3c.json
+++ b/w3c.json
@@ -1,6 +1,6 @@
 {
   "group": [
-    "11519"
+    "115198"
   ],
   "contacts": [
     "tidoust",

--- a/w3c.json
+++ b/w3c.json
@@ -1,0 +1,11 @@
+{
+  "group": [
+    "11519"
+  ],
+  "contacts": [
+    "tidoust",
+    "jernoble",
+    "mounirlamouri"
+  ],
+  "repo-type": "rec-track"
+}

--- a/w3c.json
+++ b/w3c.json
@@ -1,7 +1,5 @@
 {
-  "group": [
-    "115198"
-  ],
+  "group": 115198,
   "contacts": [
     "tidoust",
     "jernoble",


### PR DESCRIPTION
- Update spec boilerplate (copyright, status of this document section) to note that the Media WG now publishes the spec.
- Update self-references from `wicg.github.io` to `w3c.github.io`
- Add `w3c.json` file for repo tracking purpose.
- Drop local biblio for Media Playback Quality (now in specref)

Note the PR depends on https://github.com/tabatkins/bikeshed/pull/1498
... and should only be merged once the repo has been transferred to the W3C organization (#117)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/media-capabilities/pull/125.html" title="Last updated on Jul 24, 2019, 2:33 PM UTC (18ff294)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/media-capabilities/125/2980f6f...tidoust:18ff294.html" title="Last updated on Jul 24, 2019, 2:33 PM UTC (18ff294)">Diff</a>