### PR TITLE
Revert VideoConfiguration.framerate to a double. Fixes #96

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -307,7 +307,7 @@ spec: workers; urlPrefix: https://www.w3.org/TR/workers/#
           required unsigned long width;
           required unsigned long height;
           required unsigned long long bitrate;
-          required DOMString framerate;
+          required double framerate;
           boolean hasAlphaChannel;
         };
       </pre>
@@ -327,23 +327,8 @@ spec: workers; urlPrefix: https://www.w3.org/TR/workers/#
             abort these steps.
           </li>
           <li>
-            If none of the following is true, return <code>false</code> and
-            abort these steps:
-            <ul>
-              <li>
-                Applying the <a>rules for parsing floating-point number
-                values</a> to <var>configuration</var>'s
-                {{VideoConfiguration/framerate}} results in a number that is
-                finite and greater than 0.
-              </li>
-              <li>
-                <var>configuration</var>'s {{VideoConfiguration/framerate}}
-                contains one occurrence of U+002F SLASH character (/) and the
-                substrings before and after this character, when applying the
-                <a>rules for parsing floating-point number values</a> results in
-                a number that is finite and greater than 0.
-              </li>
-            </ul>
+            If {{VideoConfiguration/framerate}} is not finite or is not greater
+            than 0, return <code>false</code> and abort these steps.
           </li>
           <li>
             Return <code>true</code>.
@@ -372,8 +357,8 @@ spec: workers; urlPrefix: https://www.w3.org/TR/workers/#
       <p>
         The <dfn for='VideoConfiguration' dict-member>framerate</dfn> member
         represents the framerate of the video track. The framerate is the number
-        of frames used in one second (frames per second). It is represented
-        either as a double or as a fraction.
+        of frames used in one second (frames per second). It is represented as a
+        double.
       </p>
 
       <p>
@@ -1117,7 +1102,7 @@ spec: workers; urlPrefix: https://www.w3.org/TR/workers/#
                   width : 640,
                   height : 480,
                   bitrate : 10000,
-                  framerate : '30'
+                  framerate : 29.97
               }
             };
             navigator.mediaCapabilities.encodingInfo(configuration)


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/media-capabilities/pull/128.html" title="Last updated on Aug 15, 2019, 12:15 AM UTC (96c22d3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/media-capabilities/128/a6370dc...96c22d3.html" title="Last updated on Aug 15, 2019, 12:15 AM UTC (96c22d3)">Diff</a>