### PR TITLE
Drop custom reference for WorkerGlobalScope

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -98,9 +98,6 @@ spec: encrypted-media-draft; for: EME; urlPrefix: https://w3c.github.io/encrypte
 
 spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
     type: dfn; text: Is the environment settings object settings a secure context?; url: #settings-object
-
-spec: workers; urlPrefix: https://www.w3.org/TR/workers/#
-    type: interface; text: WorkerGlobalScope; url: the-workerglobalscope-common-interface
 </pre>
 
 <pre class='biblio'>


### PR DESCRIPTION
Web Workers are no longer being worked upon in W3C. Reference needs to be to the HTML LS spec. Bikeshed does the right thing on its own, we just need to stay out of the way...

Requested for publication to First Public Working Draft:
https://github.com/w3c/transitions/issues/213#issuecomment-579255649
(Nothing urgent with regards to this PR, I made the change manually on the document that is about to be published)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/media-capabilities/pull/148.html" title="Last updated on Jan 28, 2020, 2:58 PM UTC (9cdb6f7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/media-capabilities/148/d573555...tidoust:9cdb6f7.html" title="Last updated on Jan 28, 2020, 2:58 PM UTC (9cdb6f7)">Diff</a>