### PR TITLE
Impove encodingInfo() example

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1220,26 +1220,29 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
       <div class="example" highlight="javascript">
         <pre>
           &lt;script>
+            const contentType = 'video/webm;codecs=vp8';
+
             const configuration = {
-                type : 'record',
-                video : {
-                  contentType : 'video/webm;codecs=vp8',
-                  width : 640,
-                  height : 480,
-                  bitrate : 10000,
-                  framerate : 29.97
+              type: 'record',
+              video: {
+                contentType: contentType,
+                width: 640,
+                height: 480,
+                bitrate: 10000,
+                framerate: 29.97
               }
             };
+
             navigator.mediaCapabilities.encodingInfo(configuration)
-                .then((result) => {
-                  console.log(result.contentType + ' is:'
-                      + (result.supported ? '' : ' NOT') + ' supported,'
-                      + (result.smooth ? '' : ' NOT') + ' smooth and'
-                      + (result.powerEfficient ? '' : ' NOT') + ' power efficient');
-                })
-                .catch((err) => {
-                  console.error(err, ' caused encodingInfo to throw');
-                });
+              .then((result) => {
+                console.log(contentType + ' is:'
+                  + (result.supported ? '' : ' NOT') + ' supported,'
+                  + (result.smooth ? '' : ' NOT') + ' smooth and'
+                  + (result.powerEfficient ? '' : ' NOT') + ' power efficient');
+              })
+              .catch((err) => {
+                console.error(err, ' caused encodingInfo to reject');
+              });
           &lt;/script>
         </pre>
       </div>


### PR DESCRIPTION
This PR makes a few improvements to the `encodingInfo()` example, in response to #149:

- Fix use of `contentType`
- Improve error message
- Minor code layout change


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: write EPROTO 139705468127104:error:1407742E:SSL routines:SSL23_GET_SERVER_HELLO:tlsv1 alert protocol version:../deps/openssl/openssl/ssl/s23_clnt.c:772:
 :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 12, 2020, 11:53 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fw3c%2Fmedia-capabilities%2Fpull%2F150%2F0c65f07.html&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fchrisn%2Fmedia-capabilities%2Fpull%2F150.html)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/media-capabilities%23150.)._
</details>
