### PR TITLE
Fix encodingInfo() return type

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1065,7 +1065,7 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
       [Exposed=(Window, Worker)]
       interface MediaCapabilities {
         [NewObject] Promise&lt;MediaCapabilitiesDecodingInfo&gt; decodingInfo(MediaDecodingConfiguration configuration);
-        [NewObject] Promise&lt;MediaCapabilitiesInfo&gt; encodingInfo(MediaEncodingConfiguration configuration);
+        [NewObject] Promise&lt;MediaCapabilitiesEncodingInfo&gt; encodingInfo(MediaEncodingConfiguration configuration);
       };
     </pre>
 


### PR DESCRIPTION
The `encodingInfo()` WebIDL currently shows the return type as `Promise<MediaCapabilitiesInfo>`, which I think should be `Promise<MediaCapabilitiesEncodingInfo>`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/chrisn/media-capabilities/pull/154.html" title="Last updated on Jun 26, 2020, 2:21 PM UTC (edeb3b0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/media-capabilities/154/a9bdf79...chrisn:edeb3b0.html" title="Last updated on Jun 26, 2020, 2:21 PM UTC (edeb3b0)">Diff</a>