### PR TITLE
Extend MediaCapabilities API to WebRTC

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -58,6 +58,10 @@ spec: webrtc; urlPrefix: https://www.w3.org/TR/webrtc/#
     type: interface
         text: RTCPeerConnection; url: interface-definition
 
+spec: webrtc-svc; urlPrefix: https://www.w3.org/TR/webrtc-svc/#
+    type: interface
+        text: scalabilityMode; url: interface-definition
+
 spec: mimesniff; urlPrefix: https://mimesniff.spec.whatwg.org/#
     type: dfn; text: valid mime type; url: valid-mime-type
 
@@ -264,11 +268,12 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
         enum MediaDecodingType {
           "file",
           "media-source",
+          "webrtc"
         };
       </pre>
 
       <p>
-        A {{MediaDecodingConfiguration}} has two types:
+        A {{MediaDecodingConfiguration}} has three types:
         <ul>
           <li><dfn for='MediaDecodingType' enum-value>file</dfn> is used to
           represent a configuration that is meant to be used for a plain file
@@ -277,6 +282,9 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
           to represent a configuration that is meant to be used for playback of
           a {{MediaSource/MediaSource}} as defined in the [[media-source]]
           specification.</li>
+          <li><dfn for='MediaDecodingType' enum-value>webrtc</dfn> is used to
+          represent a configuration that is meant to be received using
+          {{RTCPeerConnection}} as defined in [[webrtc]]</span>).</li>
         </ul>
       </p>
     </section>
@@ -287,7 +295,7 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
       <pre class='idl'>
         enum MediaEncodingType {
           "record",
-          "transmission"
+          "webrtc"
         };
       </pre>
 
@@ -298,10 +306,9 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
           represent a configuration for recording of media,
           <span class="informative">e.g. using {{MediaRecorder}} as defined in
           [[mediastream-recording]]</span>.</li>
-          <li><dfn for='MediaEncodingType' enum-value>transmission</dfn> is used
-          to represent a configuration meant to be transmitted over electronic
-          means (<span class="informative">e.g. using {{RTCPeerConnection}} as
-          defined in [[webrtc]]</span>).</li>
+          <li><dfn for='MediaEncodingType' enum-value>webrtc</dfn> is used to
+          represent a configuration that is meant to be transmitted using
+          {{RTCPeerConnection}} as defined in [[webrtc]]</span>).</li>
         </ul>
       </p>
     </section>
@@ -312,14 +319,19 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
       <p>
         In the context of this specification, a MIME type is also called content
         type. A <dfn>valid media MIME type</dfn> is a string that is a <a>valid
-        MIME type</a> per [[mimesniff]]. If the MIME type does not imply a
-        codec, the string MUST also have one and only one parameter that is
-        named <code>codecs</code> with a value describing a single media codec.
-        Otherwise, it MUST contain no parameters.
+        MIME type</a> per [[mimesniff]].
       </p>
 
       <p>
-        A <dfn>valid audio MIME type</dfn> is a string that is <a>valid media
+        Please note that the definition of MIME subtypes and parameters is
+        context dependent. For {{file}}, {{media-source}}, and {{record}}, the
+        MIME types are specified as defined for HTTP, whereas for
+        {{MediaDecodingType/webrtc}} the MIME types are specified as
+        defined for RTP [[RFC4855, RFC6838]].
+      </p>
+
+      <p>
+        A <dfn>valid audio MIME type</dfn> is a string that is a <a>valid media
         MIME type</a> and for which the <code>type</code> per [[RFC7231]] is
         either <code>audio</code> or <code>application</code>.
       </p>
@@ -329,6 +341,28 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
         MIME type</a> and for which the <code>type</code> per [[RFC7231]] is
         either <code>video</code> or <code>application</code>.
       </p>
+
+      <section>
+        <h5 id='http'>HTTP</h5>
+
+        <p>
+          If the MIME type does not imply a codec, the string MUST also have one
+          and only one parameter that is named <code>codecs</code> with a value
+          describing a single media codec. Otherwise, it MUST contain no
+          parameters.
+        </p>
+      </section>
+
+      <section>
+        <h5 id='rtp'>RTP</h5>
+
+        <p>
+          The MIME types used with RTP are defined in the specifications of the
+          corresponding RTP payload formats. The codec name is typically
+          specified as subtype and zero or more parameters may be present
+          depending on the codec.
+        </p>
+      </section>
     </section>
 
     <section>
@@ -345,6 +379,7 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
           HdrMetadataType hdrMetadataType;
           ColorGamut colorGamut;
           TransferFunction transferFunction;
+          DOMString scalabilityMode;
         };
       </pre>
 
@@ -437,6 +472,12 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
         decoded media into the colors to be displayed. Valid inputs are defined
         by {{TransferFunction}}.
       </p>
+
+      <p>
+        If present, the <dfn for='VideoConfiguration' dict-member>scalabilityMode</dfn>
+        member represents the scalability mode as defined in [[webrtc-svc]].
+      </p>
+
     </section>
 
     <section>


### PR DESCRIPTION
This PR extends the MediaCapabilities API to the WebRTC use case.

-Add webrtc to MediaDecodingType
-Change transmission to webrtc to MediaEncodingType
-Clarify MIME types for webrtc.
-Add scalabilityMode to VideoConfiguration.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/drkron/media-capabilities/pull/158.html" title="Last updated on Oct 19, 2020, 11:39 AM UTC (d7ee8fd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/media-capabilities/158/7261f8f...drkron:d7ee8fd.html" title="Last updated on Oct 19, 2020, 11:39 AM UTC (d7ee8fd)">Diff</a>