### PR TITLE
Replace now gone "present" concept with "exist"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -62,7 +62,6 @@ spec: mimesniff; urlPrefix: https://mimesniff.spec.whatwg.org/#
     type: dfn; text: valid mime type; url: valid-mime-type
 
 spec: webidl; urlPrefix: https://heycam.github.io/webidl/#
-    type: dfn; text: present; url:dfn-present
     type: dfn; text: SecurityError; url:securityerror
     type: interface; text: DOMException; url:idl-DOMException
     type: dfn; text: InvalidStateError; url:invalidstateerror
@@ -216,15 +215,15 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
         MediaConfiguration</dfn>, all of the following conditions MUST be true:
         <ol>
           <li>
-            <code>audio</code> and/or <code>video</code> MUST be <a>present</a>.
+            <code>audio</code> and/or <code>video</code> MUST [=map/exist=].
           </li>
           <li>
             <code>audio</code> MUST be a <a>valid audio configuration</a> if 
-            <a>present</a>.
+            it [=map/exists=].
           </li>
           <li>
             <code>video</code> MUST be a <a>valid video configuration</a> if 
-            <a>present</a>.
+            it [=map/exists=].
           </li>
         </ol>
       </p>
@@ -237,15 +236,15 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
             It MUST be a <a>valid MediaConfiguration</a>.
           </li>
           <li>
-            If <code>keySystemConfiguration</code> is <a>present</a>:
+            If <code>keySystemConfiguration</code> [=map/exists=]:
             <ol>
               <li>
-                If <code>keySystemConfiguration.audio</code> is 
-                <a>present</a>, <code>audio</code> MUST also be <a>present</a>.
+                If <code>keySystemConfiguration.audio</code> [=map/exists=],
+                <code>audio</code> MUST also [=map/exist=].
               </li>
               <li>
-                If <code>keySystemConfiguration.video</code> is 
-                <a>present</a>, <code>video</code> MUST also be <a>present</a>.
+                If <code>keySystemConfiguration.video</code> [=map/exists=],
+                <code>video</code> MUST also [=map/exist=].
               </li>
             </ol>
           </li>
@@ -253,7 +252,7 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
       </p>
       <p>
         For a {{MediaDecodingConfiguration}} to describe [[!ENCRYPTED-MEDIA]], a
-        {{keySystemConfiguration}} MUST be <a>present</a>.
+        {{keySystemConfiguration}} MUST [=map/exist=].
       </p>
     </section>
 
@@ -615,9 +614,9 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
         The <dfn for='AudioConfiguration' dict-member>spatialRendering</dfn> 
         member indicates that the audio SHOULD be renderered spatially. The 
         details of spatial rendering SHOULD be inferred from the 
-        {{AudioConfiguration/contentType}}. If not <a>present</a>, the UA MUST 
-        presume spatialRendering is not required. When <code>true</code>, the
-        user agent SHOULD only report this configuration as 
+        {{AudioConfiguration/contentType}}. If it does not [=map/exist=], the UA
+        MUST presume spatialRendering is not required. When <code>true</code>,
+        the user agent SHOULD only report this configuration as
         <a for=MediaCapabilitiesInfo>supported</a> if it can support spatial
         rendering *for the current audio output device* without failing back to a
         non-spatial mix of the stream.
@@ -854,8 +853,7 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
               for=MediaCapabilitiesDecodingInfo>configuration</a>.
             </li>
             <li>
-              If <code>configuration.keySystemConfiguration</code> is
-              <a>present</a>:
+              If <code>configuration.keySystemConfiguration</code> [=map/exists=]:
               <ol>
                 <li>
                   Set <a for=MediaCapabilitiesDecodingInfo>keySystemAccess</a>
@@ -914,8 +912,8 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
           <dfn>Check Encrypted Decoding Support</dfn>
         </h4>
         <p>
-          Given a {{MediaDecodingConfiguration}} <var>config</var> with a
-          {{keySystemConfiguration}} <a>present</a>, this algorithm returns a
+          Given a {{MediaDecodingConfiguration}} <var>config</var> where
+          {{keySystemConfiguration}} [=map/exists=], this algorithm returns a
           {{EME/MediaKeySystemAccess}} or <code>null</code> as appropriate. The
           following steps are run:
           <ol>
@@ -955,7 +953,7 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
                 <code>config.keySystemConfiguration.sessionTypes</code>.
               </li>
               <li>
-                If {{MediaConfiguration/audio}} is <a>present</a> in <var>config</var>, set the
+                If {{MediaConfiguration/audio}} [=map/exists=] in <var>config</var>, set the
                 {{EME/audioCapabilities}} attribute to a sequence containing a
                 single {{EME/MediaKeySystemMediaCapability}}, initialized as
                 follows:
@@ -966,7 +964,7 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
                   </li>
                   <li>
                     If <code>config.keySystemConfiguration.audio</code>
-                    is <a>present</a>:
+                    [=map/exists=]:
                     <ol>
                       <li>
                         Set the {{EME/robustness}} attribute to <code>
@@ -981,7 +979,7 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
                 </ol>
               </li>
               <li>
-                If {{MediaConfiguration/video}} is <a>present</a> in <var>config</var>, set the
+                If {{MediaConfiguration/video}} [=map/exists=] in <var>config</var>, set the
                 videoCapabilities attribute to a sequence containing a single
                 {{EME/MediaKeySystemMediaCapability}}, initialized as follows:
                 <ol>
@@ -990,7 +988,7 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
                     <code>config.video.contentType</code>.
                   </li>
                   <li>
-                    If <code>config.keySystemConfiguration.video</code> is <a>present</a>:
+                    If <code>config.keySystemConfiguration.video</code> [=map/exists=]:
                     <ol>
                       <li>
                         Set the {{EME/robustness}} attribute to <code>
@@ -1077,8 +1075,8 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
           newly created {{TypeError}}.
         </li>
         <li>
-          If <code>configuration.keySystemConfiguration</code> is 
-          <a>present</a>, run the following substeps:
+          If <code>configuration.keySystemConfiguration</code> [=map/exists=],
+          run the following substeps:
           <ol>
             <li>
               If the <a>global object</a> is of type {{WorkerGlobalScope}},


### PR DESCRIPTION
The "present" concept for dictionary members was dropped from WebIDL, see:
https://github.com/heycam/webidl/commit/8d4e7ca67bcb4de476aab0411531dc97f6d17e0d

The recommendation is to rather link to the "exist" concept for maps, defined in the infra spec:
https://infra.spec.whatwg.org/#map-exists

This update fixes broken links to "present" accordinly.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/media-capabilities/pull/161.html" title="Last updated on Dec 10, 2020, 10:15 AM UTC (ef5228a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/media-capabilities/161/422ee44...tidoust:ef5228a.html" title="Last updated on Dec 10, 2020, 10:15 AM UTC (ef5228a)">Diff</a>