### PR TITLE
Define MediaCapabilitiesDecodingInfo.codecSwitchingSupported

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -28,6 +28,12 @@ spec: media-source; urlPrefix: https://www.w3.org/TR/media-source/
     type: method
         for: MediaSource; text: isTypeSupported(); url: #dom-mediasource-istypesupported
 
+spec: media-source-codec-switching; urlPrefix: https://rawgit.com/wicg/media-source/codec-switching/index.html
+    type: interface
+        for: SourceBuffer; text: SourceBuffer; url: #sourcebuffer
+    type: method
+        for: SourceBuffer; text: changeType(); url: #dom-sourcebuffer-changetype
+
 spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/;
     type: method
         for: HTMLMediaElement; text: canPlayType(); url: #dom-navigator-canplaytype
@@ -94,6 +100,8 @@ spec: encrypted-media; for: EME; urlPrefix: https://www.w3.org/TR/encrypted-medi
         text: MediaKeysRequirement; url: dom-mediakeysrequirement
         text: audioCapabilities; url: dom-mediakeysystemconfiguration-audiocapabilities
         text: contentType; url: dom-mediakeysystemmediacapability-contenttype
+    type: method
+        text: setMediaKeys(); url: dom-htmlmediaelement-setmediakeys
 
 spec: encrypted-media-draft; for: EME; urlPrefix: https://w3c.github.io/encrypted-media/#
     type: attribute
@@ -178,6 +186,21 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
       </li>
     </ul>
   </p>
+</section>
+
+<section>
+  <h2 id='definitions'>Definitions</h2>
+  <dl>
+    <dt><dfn>Decoding Pipeline</dfn></dt>
+    <dd>
+      A configuration of inernal user agent components that implement media
+      decoding. For the purposes of this specification, we concieve of user
+      agents having distinct pipelines for encrypted vs unencrypted media.
+      Moreover, user agents may support more a number of distinct encrypted
+      media pipelines, which must be signalled by using different
+      {{MediaCapabilitiesKeySystemConfiguration/keySystem}} names.
+    </dd>
+  </dl>
 </section>
 
 <section>
@@ -766,6 +789,7 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
 
     <pre class='idl'>
       dictionary MediaCapabilitiesDecodingInfo : MediaCapabilitiesInfo {
+        required boolean codecSwitchingSupported;
         required MediaKeySystemAccess keySystemAccess;
         MediaDecodingConfiguration configuration;
       };
@@ -792,6 +816,20 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
       configuration. It is worth noting that even when a device is not power
       constrained, high power usage has side effects such as increasing the
       temperature or the fans noise.
+    </p>
+
+    <p>
+      A {{MediaCapabilitiesDecodingInfo}} has an associated
+      <dfn dict-member for='MediaCapabilitiesDecodingInfo'>
+      codecSwitchingSupported</dfn> which is a boolean.
+    </p>
+
+    <p class='note'>
+      Authors can use {{MediaCapabilitiesDecodingInfo/codecSwitchingSupported}}
+      to determine whether the user agent supports codec switching via
+      {{SourceBuffer/changeType()}} within the described
+      <a>decoding pipeline</a>. Note that switching between
+      <a>decoding pipelines</a> is a separate quality of implementation issue as desribed by {{EME/setMediaKeys()}}.
     </p>
 
     <p>
@@ -939,6 +977,21 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
               power source in order to determine the decoding power
               efficiency unless the device's power source has side effects
               such as enabling different decoding modules.
+            </li>
+            <li>
+              If <code>configuration.type</code> is set to {{MediaDecodingType/media-source}}:
+              <ol>
+                <li>
+                  Let <var>pipeline</var> be the <a>decoding pipeline</a>
+                  described by <var>configuration</var>.
+                </li>
+                <li>
+                  If <var>pipeline</var> is able to support dynamic codec
+                  switching via {{SourceBuffer}} {{SourceBuffer/changeType()}},
+                  set {{MediaCapabilitiesDecodingInfo/codecSwitchingSupported}}
+                  to <code>true</code>. Otherwise, set it to <code>false</code>.
+                </li>
+              </ol>
             </li>
             <li>
               Return <var>info</var>.


### PR DESCRIPTION
Implements the latest proposal from the discussion in #102. This adds a single `codecSwitchingSupported` boolean to the MediaCapabilitiesDecodingInfo dictionary that indicates whether sourceBuffer.changeType() may be used to switch codecs within the "decoding pipeline" as described by the config passed to mediaCapabilties.decodingInfo().

This PR creates a definition of "decoding pipeline" which distinguishes between clear vs eme plabyack (and eme plabyacks of differently named key systems). It may occur that a given UA does not really have a separate pipeline for clear vs its platform key system, but this is still allowed by the specification as that difference is not observable. 
