### PR TITLE
Highlight .bs files as HTML

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.bs linguist-language=HTML


### PR DESCRIPTION
With this PR, [index.bs](https://github.com/w3c/media-capabilities/blob/main/index.bs) will be syntax highlighted. See https://github.com/github/linguist/blob/master/docs/overrides.md

The result seems to be better than `linguist-language=Markdown`.