### PR TITLE
Update spec editors

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7,8 +7,8 @@ TR: https://www.w3.org/TR/media-capabilities/
 Shortname: media-capabilities
 Level: None
 Group: mediawg
-Editor: Jean-Yves Avenard, w3cid xxx, Apple Inc. https://www.apple.com/
-Editor: Will Cassella, w3cid xxx, Google Inc. https://www.google.com/
+Editor: Jean-Yves Avenard, w3cid 115886, Apple Inc. https://www.apple.com/
+Editor: Will Cassella, w3cid 139598, Google Inc. https://www.google.com/
 
 Former Editor: Mounir Lamouri, w3cid 45389, Google Inc. https://www.google.com/
 Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/

--- a/index.bs
+++ b/index.bs
@@ -7,9 +7,12 @@ TR: https://www.w3.org/TR/media-capabilities/
 Shortname: media-capabilities
 Level: None
 Group: mediawg
-Editor: Mounir Lamouri, w3cid 45389, Google Inc. https://www.google.com/
-Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
-Editor: Vi Nguyen, w3cid 116349, Microsoft Corporation https://www.microsoft.com/
+Editor: Jean-Yves Avenard, w3cid xxx, Apple Inc. https://www.apple.com/
+Editor: Will Cassella, w3cid xxx, Google Inc. https://www.google.com/
+
+Former Editor: Mounir Lamouri, w3cid 45389, Google Inc. https://www.google.com/
+Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
+Former Editor: Vi Nguyen, w3cid 116349, Microsoft Corporation https://www.microsoft.com/
 
 Abstract: This specification intends to provide APIs to allow websites to make
 Abstract: an optimal decision when picking media content for the user. The APIs
@@ -122,12 +125,6 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
         "publisher": "SMPTE",
         "date": "2016",
         "id": "SMPTE-ST-2094"
-    },
-    "ENCRYPTED-MEDIA-DRAFT": {
-        "href": "https://w3c.github.io/encrypted-media",
-        "title": "Encrypted Media Extensions",
-        "publisher": "W3C",
-        "date": "13 December 2019"
     }
 }
 </pre>
@@ -780,7 +777,7 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
 
     <p>
       The <dfn for='KeySystemTrackConfiguration' dict-member>encryptionScheme</dfn>
-      member represents an {{EME/encryptionScheme}} as described in [[!ENCRYPTED-MEDIA-DRAFT]].
+      member represents an {{EME/encryptionScheme}}.
     </p>
   </section>
 

--- a/index.bs
+++ b/index.bs
@@ -125,6 +125,12 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
         "publisher": "SMPTE",
         "date": "2016",
         "id": "SMPTE-ST-2094"
+    },
+    "ENCRYPTED-MEDIA-DRAFT": {
+        "href": "https://w3c.github.io/encrypted-media",
+        "title": "Encrypted Media Extensions",
+        "publisher": "W3C",
+        "date": "13 December 2019"
     }
 }
 </pre>
@@ -777,7 +783,7 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
 
     <p>
       The <dfn for='KeySystemTrackConfiguration' dict-member>encryptionScheme</dfn>
-      member represents an {{EME/encryptionScheme}}.
+      member represents an {{EME/encryptionScheme}} as described in [[!ENCRYPTED-MEDIA-DRAFT]].
     </p>
   </section>
 


### PR DESCRIPTION
This PR add Jean-Yves and Will as co-editors, and move Chris, Mounir, and Vi (who is also no longer active in the WG) to former editors. 

See https://www.w3.org/2022/11/08-mediawg-minutes.html#t07 and https://lists.w3.org/Archives/Public/public-media-wg/2022Nov/0004.html

@willcassella @jyavenard We just need to add your w3cids to complete this PR.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/media-capabilities/pull/200.html" title="Last updated on Nov 17, 2022, 9:40 AM UTC (3875d1d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/media-capabilities/200/5793c9b...3875d1d.html" title="Last updated on Nov 17, 2022, 9:40 AM UTC (3875d1d)">Diff</a>