### PR TITLE
Update introduction section

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -141,7 +141,7 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
 
   <p>
     This specification defines an API to query the user agent with regards
-    to the audio and video decoding and encoding abilities of the device,
+    to its audio and video decoding and encoding capabilities,
     based on information such as the codecs, profile, resolution, bitrates,
     etc., of the media. The API indicates if the configuration is supported
     and whether the playback should be smooth and power efficient.

--- a/index.bs
+++ b/index.bs
@@ -147,17 +147,17 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
     and whether the playback should be smooth and power efficient.
   </p>
   <p>
-    The intent of the decoding capabilities API is to provide a powerful
+    The intent of the decoding capabilities API is to provide a more capable
     replacement for APIs such as {{MediaSource/isTypeSupported()}} or
-    {{HTMLMediaElement/canPlayType()}} which are vague and mostly help
+    {{HTMLMediaElement/canPlayType()}}, which are vague and mostly help
     callers know if something cannot be decoded but not how well it
     should perform.
   </p>
   <p>
     This specification focuses on encoding and decoding capabilities.
     It is expected to be used with other web APIs that provide information about
-    the display properties, such as supported color gamut or dynamic range abilities,
-    to enable web applications to pick the right content for the display and to,
+    the display properties, such as supported color gamut or dynamic range capabilities,
+    which enable web applications to pick the right content for the display and to,
     for example, avoid providing HDR content to an SDR display.
   </p>
 </section>

--- a/index.bs
+++ b/index.bs
@@ -151,20 +151,20 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
           efficient.
         </p>
         <p>
-          The intent of purposes of the decoding capabilities API is to provide
-          a powerful replacement to API such as
+          The intent of the decoding capabilities API is to provide
+          a powerful replacement to APIs such as
           {{MediaSource/isTypeSupported()}} or
-          {{HTMLMediaElement/canPlayType()}} which are vague and mostly help the
-          callers to know if something can not be decoded but not how well it
+          {{HTMLMediaElement/canPlayType()}} which are vague and mostly help
+          callers know if something cannot be decoded but not how well it
           should perform.
         </p>
       </li>
       <li>
         <p>
-          Better information about the display properties such as supported
-          color gamut or dynamic range abilities in order to pick the right
-          content for the display and avoid providing HDR content to an SDR
-          display.
+          Better information about the display properties, such as supported
+          color gamut or dynamic range abilities, in order to pick the right
+          content for the display and to, for example, avoid providing HDR
+          content to an SDR display.
         </p>
       </li>
       <li>
@@ -211,7 +211,7 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
 
       <p>
         The input to the decoding capabilities is represented by a
-        {{MediaDecodingConfiguration}} dictionary and the input of the encoding
+        {{MediaDecodingConfiguration}} dictionary and the input to the encoding
         capabilities by a {{MediaEncodingConfiguration}} dictionary.
       </p>
       <p>
@@ -278,7 +278,7 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
         A {{MediaDecodingConfiguration}} has three types:
         <ul>
           <li><dfn for='MediaDecodingType' enum-value>file</dfn> is used to
-          represent a configuration that is meant to be used for a plain file
+          represent a configuration that is meant to be used for plain file
           playback.</li>
           <li><dfn for='MediaDecodingType' enum-value>media-source</dfn> is used
           to represent a configuration that is meant to be used for playback of
@@ -306,7 +306,7 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
         <ul>
           <li><dfn for='MediaEncodingType' enum-value>record</dfn> is used to
           represent a configuration for recording of media,
-          <span class="informative">e.g. using {{MediaRecorder}} as defined in
+          <span class="informative">e.g., using {{MediaRecorder}} as defined in
           [[mediastream-recording]]</span>.</li>
           <li><dfn for='MediaEncodingType' enum-value>webrtc</dfn> is used to
           represent a configuration that is meant to be transmitted using
@@ -667,14 +667,14 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
 
       <p>
         The <dfn for='AudioConfiguration' dict-member>bitrate</dfn> member
-        represents the number of average bitrate of the audio track. The bitrate
+        represents the average bitrate of the audio track. The bitrate
         is the number of bits used to encode a second of the audio track.
       </p>
 
       <p>
         The <dfn for='AudioConfiguration' dict-member>samplerate</dfn>
-        represents the samplerate of the audio track in. The samplerate is the
-        number of samples of audio carried per second. samplerate is only
+        member represents the samplerate of the audio track in. The samplerate
+        is the number of samples of audio carried per second. samplerate is only
         applicable to the decoding types {{media-source}}, {{file}}, and
         {{MediaDecodingType/webrtc}} and the encoding type
         {{MediaEncodingType/webrtc}}.
@@ -821,11 +821,11 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
 
     <p class='note'>
       Authors can use {{MediaCapabilitiesInfo/powerEfficient}} in concordance
-      with the Battery Status API [[battery-status]] in order to determine
+      with the Battery Status API [[battery-status]] to determine
       whether the media they would like to play is appropriate for the user
       configuration. It is worth noting that even when a device is not power
       constrained, high power usage has side effects such as increasing the
-      temperature or the fans noise.
+      temperature or fan noise.
     </p>
 
     <p>
@@ -1002,7 +1002,7 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
               context's <a>Document</a>.
             </li>
             <li>
-              Let <var>implementation</var> be the implementation of <code>config.keySystemConfiguration.keySystem</code>
+              Let <var>implementation</var> be the implementation of <code>config.keySystemConfiguration.keySystem</code>.
             </li>
 
             <li>
@@ -1042,11 +1042,11 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
                     <ol>
                       <li>
                         Set the {{EME/robustness}} attribute to <code>
-                        config.keySystemConfiguration.audio.robustness</code>
+                        config.keySystemConfiguration.audio.robustness</code>.
                       </li>
                       <li>
                         Set the {{EME/encryptionScheme}} attribute to <code>
-                        config.keySystemConfiguration.audio.encryptionScheme</code>
+                        config.keySystemConfiguration.audio.encryptionScheme</code>.
                       </li>
                     </ol>
                   </li>
@@ -1070,7 +1070,7 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
                       </li>
                       <li>
                         Set the {{EME/encryptionScheme}} attribute to <code>
-                        config.keySystemConfiguration.video.encryptionScheme</code>
+                        config.keySystemConfiguration.video.encryptionScheme</code>.
                       </li>
                     </ol>
                   </li>
@@ -1106,7 +1106,7 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
                 </li>
               </ol>
             </li>
-            <li>Return <var>access</var></li>
+            <li>Return <var>access</var>.</li>
           </ol>
         </p>
       </section>
@@ -1220,7 +1220,7 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
   <section>
     <p>
       This specification does not introduce any security-sensitive information
-      or APIs but is provides an easier access to some information that can be
+      or APIs but it provides easier access to some information that can be
       used to fingerprint users.
     </p>
 
@@ -1234,7 +1234,7 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
         already be discovered via experimentation with the exception that the
         API will likely provide more accurate and consistent information. This
         information is expected to have a high correlation with other
-        information already available to the web pages as a given class of
+        information already available to web pages as a given class of
         device is expected to have very similar decoding/encoding capabilities.
         In other words, high end devices from a certain year are expected to
         decode some type of videos while older devices may not. Therefore, it is
@@ -1243,8 +1243,8 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
       </p>
 
       <p>
-        HDR detection is more nuanced. Adding colorGamut, transferFunction, and
-        hdrMetadataType has the potential to add significant entropy. However,
+        HDR detection is more nuanced. Adding {{colorGamut}}, {{transferFunction}}, and
+        {{hdrMetadataType}} has the potential to add significant entropy. However,
         for UAs whose decoders are implemented in software and therefore whose
         capabilities are fixed across devices, this feature adds no effective
         entropy. Additionally, for many cases, devices tend to fall into large
@@ -1255,7 +1255,7 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
       <p>
         If an implementation wishes to implement a fingerprint-proof version of
         this specification, it would be recommended to fake a given set of
-        capabilities (ie. decode up to 1080p VP9, etc.) instead of returning
+        capabilities (i.e., decode up to 1080p VP9, etc.) instead of returning
         always yes or always no as the latter approach could considerably
         degrade the user's experience. Another mitigation could be to limit
         these Web APIs to top-level browsing contexts. Yet another is to use a
@@ -1415,7 +1415,7 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
       </div>
 
       <div class="note">
-        The following example can also be found in e.g.
+        The following example can also be found in
         <a href="https://codepen.io/miguelao/pen/bWNwej/left?editors=0010#0">
         this codepen</a> with minimal modifications.
       </div>

--- a/index.bs
+++ b/index.bs
@@ -143,8 +143,8 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
     This specification defines an API to query the user agent with regards
     to the audio and video decoding and encoding abilities of the device,
     based on information such as the codecs, profile, resolution, bitrates,
-    etc., of the media. The API exposes information such as whether the
-    playback should be smooth and power efficient.
+    etc., of the media. The API indicates if the configuration is supported
+    and whether the playback should be smooth and power efficient.
   </p>
   <p>
     The intent of the decoding capabilities API is to provide a powerful

--- a/index.bs
+++ b/index.bs
@@ -140,43 +140,25 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
   <em>This section is non-normative</em>
 
   <p>
-    This specification relies on exposing the following sets of properties:
-    <ul>
-      <li>
-        <p>
-          An API to query the user agent with regards to the decoding and
-          encoding abilities of the device based on information such as the
-          codecs, profile, resolution, bitrates, etc. The API exposes
-          information such as whether the playback should be smooth and power
-          efficient.
-        </p>
-        <p>
-          The intent of the decoding capabilities API is to provide
-          a powerful replacement to APIs such as
-          {{MediaSource/isTypeSupported()}} or
-          {{HTMLMediaElement/canPlayType()}} which are vague and mostly help
-          callers know if something cannot be decoded but not how well it
-          should perform.
-        </p>
-      </li>
-      <li>
-        <p>
-          Better information about the display properties, such as supported
-          color gamut or dynamic range abilities, in order to pick the right
-          content for the display and to, for example, avoid providing HDR
-          content to an SDR display.
-        </p>
-      </li>
-      <li>
-        <p>
-          Real time feedback about the playback so an adaptative streaming can
-          alter the quality of the content based on actual user perceived
-          quality. Such information will allow websites to react to a pick of
-          CPU/GPU usage in real time. It is expected that this will be tackled
-          as part of the [[media-playback-quality]] specification.
-        </p>
-      </li>
-    </ul>
+    This specification defines an API to query the user agent with regards
+    to the audio and video decoding and encoding abilities of the device,
+    based on information such as the codecs, profile, resolution, bitrates,
+    etc., of the media. The API exposes information such as whether the
+    playback should be smooth and power efficient.
+  </p>
+  <p>
+    The intent of the decoding capabilities API is to provide a powerful
+    replacement for APIs such as {{MediaSource/isTypeSupported()}} or
+    {{HTMLMediaElement/canPlayType()}} which are vague and mostly help
+    callers know if something cannot be decoded but not how well it
+    should perform.
+  </p>
+  <p>
+    This specification focuses on encoding and decoding capabilities.
+    It is expected to be used with other web APIs that provide information about
+    the display properties, such as supported color gamut or dynamic range abilities,
+    to enable web applications to pick the right content for the display and to,
+    for example, avoid providing HDR content to an SDR display.
   </p>
 </section>
 

--- a/index.bs
+++ b/index.bs
@@ -611,7 +611,7 @@ spec: encrypted-media-draft; for: EME; urlPrefix: https://w3c.github.io/encrypte
 
       <p>
         The <dfn for='AudioConfiguration' dict-member>samplerate</dfn>
-        member represents the samplerate of the audio track in. The samplerate
+        member represents the sample rate of the audio track. The sample rate
         is the number of samples of audio carried per second. samplerate is only
         applicable to the decoding types {{media-source}}, {{file}}, and
         {{MediaDecodingType/webrtc}} and the encoding type

--- a/index.bs
+++ b/index.bs
@@ -144,7 +144,7 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
     to its audio and video decoding and encoding capabilities,
     based on information such as the codecs, profile, resolution, bitrates,
     etc., of the media. The API indicates if the configuration is supported
-    and whether the playback should be smooth and power efficient.
+    and whether the playback is expected to be smooth and power efficient.
   </p>
   <p>
     The intent of the decoding capabilities API is to provide a more capable

--- a/index.bs
+++ b/index.bs
@@ -107,14 +107,7 @@ spec: encrypted-media-draft; for: EME; urlPrefix: https://w3c.github.io/encrypte
     to its audio and video decoding and encoding capabilities,
     based on information such as the codecs, profile, resolution, bitrates,
     etc., of the media. The API indicates if the configuration is supported
-    and whether the playback is expected to be smooth and power efficient.
-  </p>
-  <p>
-    The intent of the decoding capabilities API is to provide a more capable
-    replacement for APIs such as {{MediaSource/isTypeSupported()}} or
-    {{HTMLMediaElement/canPlayType()}}, which are vague and mostly help
-    callers know if something cannot be decoded but not how well it
-    performs.
+    and whether the playback is expected to be smooth and/or power efficient.
   </p>
   <p>
     This specification focuses on encoding and decoding capabilities.

--- a/index.bs
+++ b/index.bs
@@ -151,7 +151,7 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
     replacement for APIs such as {{MediaSource/isTypeSupported()}} or
     {{HTMLMediaElement/canPlayType()}}, which are vague and mostly help
     callers know if something cannot be decoded but not how well it
-    should perform.
+    performs.
   </p>
   <p>
     This specification focuses on encoding and decoding capabilities.


### PR DESCRIPTION
This PR updates the introduction to explain that display capability detection happens elsewhere, and removes mention of Media Playback Quality.

It also fixes a few grammatical issues I found elsewhere in the spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/chrisn/media-capabilities/pull/204.html" title="Last updated on Jul 18, 2024, 10:55 AM UTC (64f4164)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/media-capabilities/204/35e5eaa...chrisn:64f4164.html" title="Last updated on Jul 18, 2024, 10:55 AM UTC (64f4164)">Diff</a>