### PR TITLE
Minor editorial tweak to spatialRendering definition

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -653,14 +653,14 @@ spec: encrypted-media-draft; for: EME; urlPrefix: https://w3c.github.io/encrypte
 
       <p>
         The <dfn for='AudioConfiguration' dict-member>spatialRendering</dfn>
-        member indicates that the audio SHOULD be renderered spatially. The
+        member indicates that the audio SHOULD be rendered spatially. The
         details of spatial rendering SHOULD be inferred from the
         {{AudioConfiguration/contentType}}. If it does not [=map/exist=], the UA
-        MUST presume spatialRendering is not required. When <code>true</code>,
+        MUST presume spatial rendering is not required. When <code>true</code>,
         the user agent SHOULD only report this configuration as
         {{MediaCapabilitiesInfo/supported}} if it can support spatial
-        rendering *for the current audio output device* without failing back to a
-        non-spatial mix of the stream. spatialRendering is only applicable to
+        rendering for the current audio output device without failing back to a
+        non-spatial mix of the stream. {{spatialRendering}} is only applicable to
         {{MediaDecodingConfiguration}} for types {{media-source}} and {{file}}.
       </p>
     </section>


### PR DESCRIPTION
This PR fixes a typo "renderering", the emphasis around "for the current audio device" seemed unnecessary, and clarifies `spatialRendering` the dictionary member vs the activity of spatial rendering.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/media-capabilities/pull/211.html" title="Last updated on Jan 12, 2024, 5:21 PM UTC (2622504)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/media-capabilities/211/b47e97e...2622504.html" title="Last updated on Jan 12, 2024, 5:21 PM UTC (2622504)">Diff</a>