### PR TITLE
Move Will Cassella to former editor

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -8,8 +8,8 @@ Shortname: media-capabilities
 Level: None
 Group: mediawg
 Editor: Jean-Yves Avenard, w3cid 115886, Apple Inc. https://www.apple.com/
-Editor: Will Cassella, w3cid 139598, Google Inc. https://www.google.com/
 
+Former Editor: Will Cassella, w3cid 139598, Google Inc. https://www.google.com/
 Former Editor: Mounir Lamouri, w3cid 45389, Google Inc. https://www.google.com/
 Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 Former Editor: Vi Nguyen, w3cid 116349, Microsoft Corporation https://www.microsoft.com/


### PR DESCRIPTION
Publication to /TR currently fails because spec editors must be working group participants, and Will is no longer around. This is per W3C Process, see: https://www.w3.org/2023/Process-20231103/#publication


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/media-capabilities/pull/214.html" title="Last updated on Feb 9, 2024, 7:28 AM UTC (6b2e006)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/media-capabilities/214/b47e97e...6b2e006.html" title="Last updated on Feb 9, 2024, 7:28 AM UTC (6b2e006)">Diff</a>