### PR TITLE
Clarify meaning of spatialScalability

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -464,10 +464,12 @@ spec: encrypted-media-draft; for: EME; urlPrefix: https://w3c.github.io/encrypte
         member represents the ability to do spatial prediction, that is,
         using frames of a resolution different than the current resolution as
         dependencies. If absent, spatialScalability will default to
-        <code>false</code>. spatialScalability is closely coupled to
-        {{VideoConfiguration/scalabilityMode}} in the sense that streams encoded
-        with modes using spatial scalability (e.g. "L2T1") can only be decoded
-        if spatialScalability is supported. spatialScalability is only
+        <code>false</code>. If spatialScalability is set to <code>true</code>,
+        the decoder can decode any {{VideoConfiguration/scalabilityMode}} 
+        that the encoder can encode for the configured codec.  If spatialScalability
+        is set to <code>false</code>, the decoder cannot decode spatial scalability
+        modes, but can decode all other {{VideoConfiguration/scalabilityMode}} values
+        that the encoder can encode for the configured codec. spatialScalability is only
         applicable to {{MediaDecodingConfiguration}} for types {{media-source}},
         {{file}}, and {{MediaDecodingType/webrtc}}.
       </p>

--- a/index.bs
+++ b/index.bs
@@ -463,7 +463,7 @@ spec: encrypted-media-draft; for: EME; urlPrefix: https://w3c.github.io/encrypte
         If present, the <dfn for='VideoConfiguration' dict-member>spatialScalability</dfn>
         member represents the ability to do spatial prediction, that is,
         using frames of a resolution different than the current resolution as
-        dependencies. If absent, spatialScalability defaults to
+        dependencies. If absent, {{VideoConfiguration/spatialScalability}} defaults to
         <code>false</code>. If {{VideoConfiguration/spatialScalability}} is set to <code>true</code>,
         the decoder can decode any {{VideoConfiguration/scalabilityMode}} 
         that the encoder can encode for the configured codec.  If {{VideoConfiguration/spatialScalability}}

--- a/index.bs
+++ b/index.bs
@@ -463,7 +463,7 @@ spec: encrypted-media-draft; for: EME; urlPrefix: https://w3c.github.io/encrypte
         If present, the <dfn for='VideoConfiguration' dict-member>spatialScalability</dfn>
         member represents the ability to do spatial prediction, that is,
         using frames of a resolution different than the current resolution as
-        dependencies. If absent, spatialScalability will default to
+        dependencies. If absent, spatialScalability defaults to
         <code>false</code>. If {{VideoConfiguration/spatialScalability}} is set to <code>true</code>,
         the decoder can decode any {{VideoConfiguration/scalabilityMode}} 
         that the encoder can encode for the configured codec.  If {{VideoConfiguration/spatialScalability}}

--- a/index.bs
+++ b/index.bs
@@ -464,12 +464,12 @@ spec: encrypted-media-draft; for: EME; urlPrefix: https://w3c.github.io/encrypte
         member represents the ability to do spatial prediction, that is,
         using frames of a resolution different than the current resolution as
         dependencies. If absent, spatialScalability will default to
-        <code>false</code>. If spatialScalability is set to <code>true</code>,
+        <code>false</code>. If {{VideoConfiguration/spatialScalability}} is set to <code>true</code>,
         the decoder can decode any {{VideoConfiguration/scalabilityMode}} 
-        that the encoder can encode for the configured codec.  If spatialScalability
+        that the encoder can encode for the configured codec.  If {{VideoConfiguration/spatialScalability}}
         is set to <code>false</code>, the decoder cannot decode spatial scalability
         modes, but can decode all other {{VideoConfiguration/scalabilityMode}} values
-        that the encoder can encode for the configured codec. spatialScalability is only
+        that the encoder can encode for the configured codec. {{VideoConfiguration/spatialScalability}} is only
         applicable to {{MediaDecodingConfiguration}} for types {{media-source}},
         {{file}}, and {{MediaDecodingType/webrtc}}.
       </p>

--- a/index.bs
+++ b/index.bs
@@ -466,7 +466,7 @@ spec: encrypted-media-draft; for: EME; urlPrefix: https://w3c.github.io/encrypte
         dependencies. If absent, {{VideoConfiguration/spatialScalability}} defaults to
         <code>false</code>. If {{VideoConfiguration/spatialScalability}} is set to <code>true</code>,
         the decoder can decode any {{VideoConfiguration/scalabilityMode}} 
-        that the encoder can encode for the configured codec.  If {{VideoConfiguration/spatialScalability}}
+        that the encoder can encode for the configured codec. If {{VideoConfiguration/spatialScalability}}
         is set to <code>false</code>, the decoder cannot decode spatial scalability
         modes, but can decode all other {{VideoConfiguration/scalabilityMode}} values
         that the encoder can encode for the configured codec. {{VideoConfiguration/spatialScalability}} is only


### PR DESCRIPTION
[WebRTC-SVC Section 7.1](https://w3c.github.io/webrtc-svc/#persistent-information) includes text relating to `spatialScalability` which appears more appropriate for the Media Capabilities specification. 
 
Related: https://github.com/w3c/webrtc-svc/issues/103


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/media-capabilities/pull/218.html" title="Last updated on Jun 12, 2025, 11:27 AM UTC (60fb9d2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/media-capabilities/218/1774c15...60fb9d2.html" title="Last updated on Jun 12, 2025, 11:27 AM UTC (60fb9d2)">Diff</a>