### PR TITLE
Make keySystemAccess nullable in MediaCapabilitiesDecodingInfo

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -726,7 +726,7 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
 
     <pre class='idl'>
       dictionary MediaCapabilitiesDecodingInfo : MediaCapabilitiesInfo {
-        required MediaKeySystemAccess keySystemAccess;
+        required MediaKeySystemAccess? keySystemAccess;
         MediaDecodingConfiguration configuration;
       };
     </pre>


### PR DESCRIPTION
See #219, and [WPT test cases](https://github.com/web-platform-tests/wpt/blob/master/media-capabilities/decodingInfoEncryptedMedia.https.html).

@jyavenard and @marcoscaceres It looks like Safari doesn't implement this?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/media-capabilities/pull/223.html" title="Last updated on Jul 17, 2024, 12:28 PM UTC (002074c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/media-capabilities/223/a9bdf79...002074c.html" title="Last updated on Jul 17, 2024, 12:28 PM UTC (002074c)">Diff</a>