### PR TITLE
Adds a task source and uses it for resolving promises.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,22 @@
 LOCAL_BIKESHED := $(shell command -v bikeshed 2> /dev/null)
 
 index.html: index.bs
-#	./format.py $<
 ifndef LOCAL_BIKESHED
 	curl https://api.csswg.org/bikeshed/ -f -F file=@$< >$@;
 else
 	bikeshed spec
 endif
+
+ifdef LOCAL_BIKESHED
+.PHONY: lint watch
+
+lint: index.bs
+	bikeshed --print=plain --dry-run --force spec --line-numbers $<
+
+watch: index.bs
+	@echo 'Browse to file://${PWD}/index.html'
+	bikeshed --print=plain watch $<
+endif  # LOCAL_BIKESHED
+
+
+

--- a/index.bs
+++ b/index.bs
@@ -26,6 +26,10 @@ Abstract: based on the device's display.
 !Version History: <a href='https://github.com/w3c/media-capabilities/commits'>https://github.com/w3c/media-capabilities/commits</a>
 </pre>
 
+<pre class='link-defaults'>
+spec:html; type:dfn; for:realm; text:global object
+</pre>
+
 <pre class='anchors'>
 spec: media-source; urlPrefix: https://www.w3.org/TR/media-source/
     type: interface
@@ -39,6 +43,10 @@ spec: mediastream-recording; urlPrefix: https://www.w3.org/TR/mediastream-record
 
 spec: mimesniff; urlPrefix: https://mimesniff.spec.whatwg.org/#
     type: dfn; text: valid mime type; url: valid-mime-type
+
+spec: ecmascript; urlPrefix: https://tc39.es/ecma262/multipage/
+    type: dfn;
+        text: current realm; url: executable-code-and-execution-contexts.html#sec-code-realms
 </pre>
 
 <pre class='biblio'>
@@ -1052,8 +1060,24 @@ spec: mimesniff; urlPrefix: https://mimesniff.spec.whatwg.org/#
       };
     </xmp>
 
+  <section>
+    <h4 id='task-source'>Media Capabilities Task Source</h4>
     <p>
-      The {{decodingInfo()}} method method MUST run the following steps:
+      The [=task source=] for the tasks mentioned in this specification
+      is the <dfn>media capabilities task source</dfn>.
+    </p>
+
+    <p>
+      When an algorithm <dfn lt="queue a Media Capabilities task">queues
+      a Media Capabilities task</dfn> <var>T</var>, the user agent
+      MUST [=queue a global task=] <var>T</var> on the [=media capabilities
+      task source=] using the [=global object=] of the [=current realm=].
+    </p>
+  </section>
+  <section>
+    <h4 id='decodinginfo-method'>decodingInfo() Method</h4>
+    <p>
+      The {{decodingInfo()}} method MUST run the following steps:
       <ol>
         <li>
           If <var>configuration</var> is not a <a>valid
@@ -1077,15 +1101,23 @@ spec: mimesniff; urlPrefix: https://mimesniff.spec.whatwg.org/#
           </ol>
         </li>
         <li>
-          Let <var>p</var> be a new promise.
-        </li>
-        <li>
-          <a>In parallel</a>, run the <a>Create a
-          MediaCapabilitiesDecodingInfo</a> algorithm with
-          <var>configuration</var> and resolve <var>p</var> with its result.
+          Let <var>p</var> be a new Promise.
         </li>
         <li>
           Return <var>p</var>.
+        </li>
+        <li>
+          <a>In parallel</a>, run following steps:
+          <ol>
+            <li>
+              Run the <a>Create a MediaCapabilitiesDecodingInfo</a> algorithm
+              with <var>configuration</var>.
+            </li>
+            <li>
+              <a>Queue a Media Capabilities task</a> to resolve <var>p</var>
+              with its result.
+            </li>
+          </ol>
         </li>
       </ol>
     </p>
@@ -1096,7 +1128,10 @@ spec: mimesniff; urlPrefix: https://mimesniff.spec.whatwg.org/#
       calls should only be made when the author intends to create and use a
       {{MediaKeys}} object with the provided configuration.
     </p>
+    </section>
 
+    <section>
+    <h4 id='encodinginfo-method'>encodingInfo() Method</h4>
     <p>
       The {{encodingInfo()}} method MUST run the following steps:
       <ol>
@@ -1105,20 +1140,28 @@ spec: mimesniff; urlPrefix: https://mimesniff.spec.whatwg.org/#
           return a Promise rejected with a newly created {{TypeError}}.
         </li>
         <li>
-          Let <var>p</var> be a new promise.
-        </li>
-        <li>
-          <a>In parallel</a>, run the <a>Create a MediaCapabilitiesEncodingInfo</a>
-          algorithm with <var>configuration</var> and resolve <var>p</var>
-          with its result.
+          Let <var>p</var> be a new Promise.
         </li>
         <li>
           Return <var>p</var>.
         </li>
+        <li>
+          Run the following steps <a>in parallel</a>.
+            <ol>
+              <li>
+                Run the <a>Create a MediaCapabilitiesEncodingInfo</a>
+                algorithm with <var>configuration</var>.
+              </li>
+              <li>
+               <a>Queue a Media Capabilities task</a> to resolve <var>p</var> with
+               its result.
+             </li>
+           </ol>
+        </li>
       </ol>
     </p>
-
-  </section>
+    </section>
+  </Section>
 </section>
 
 <section class='non-normative'>

--- a/index.bs
+++ b/index.bs
@@ -1071,7 +1071,7 @@ spec: ecmascript; urlPrefix: https://tc39.es/ecma262/multipage/
       When an algorithm <dfn lt="queue a Media Capabilities task">queues
       a Media Capabilities task</dfn> <var>T</var>, the user agent
       MUST [=queue a global task=] <var>T</var> on the [=media capabilities
-      task source=] using the [=global object=] of the [=current realm=].
+      task source=] using the [=global object=] of the [=current realm record=].
     </p>
   </section>
   <section>

--- a/index.bs
+++ b/index.bs
@@ -43,10 +43,6 @@ spec: mediastream-recording; urlPrefix: https://www.w3.org/TR/mediastream-record
 
 spec: mimesniff; urlPrefix: https://mimesniff.spec.whatwg.org/#
     type: dfn; text: valid mime type; url: valid-mime-type
-
-spec: ecmascript; urlPrefix: https://tc39.es/ecma262/multipage/
-    type: dfn;
-        text: current realm; url: executable-code-and-execution-contexts.html#sec-code-realms
 </pre>
 
 <pre class='biblio'>
@@ -1071,7 +1067,7 @@ spec: ecmascript; urlPrefix: https://tc39.es/ecma262/multipage/
       When an algorithm <dfn lt="queue a Media Capabilities task">queues
       a Media Capabilities task</dfn> <var>T</var>, the user agent
       MUST [=queue a global task=] <var>T</var> on the [=media capabilities
-      task source=] using the [=global object=] of the [=current realm record=].
+      task source=] using the [=global object=] of the [=the current realm record=].
     </p>
   </section>
   <section>
@@ -1104,10 +1100,7 @@ spec: ecmascript; urlPrefix: https://tc39.es/ecma262/multipage/
           Let <var>p</var> be a new Promise.
         </li>
         <li>
-          Return <var>p</var>.
-        </li>
-        <li>
-          <a>In parallel</a>, run following steps:
+          Run the following steps <a>in parallel</a>:
           <ol>
             <li>
               Run the <a>Create a MediaCapabilitiesDecodingInfo</a> algorithm
@@ -1118,6 +1111,9 @@ spec: ecmascript; urlPrefix: https://tc39.es/ecma262/multipage/
               with its result.
             </li>
           </ol>
+        </li>
+        <li>
+          Return <var>p</var>.
         </li>
       </ol>
     </p>
@@ -1143,10 +1139,7 @@ spec: ecmascript; urlPrefix: https://tc39.es/ecma262/multipage/
           Let <var>p</var> be a new Promise.
         </li>
         <li>
-          Return <var>p</var>.
-        </li>
-        <li>
-          Run the following steps <a>in parallel</a>.
+          Run the following steps <a>in parallel</a>:
             <ol>
               <li>
                 Run the <a>Create a MediaCapabilitiesEncodingInfo</a>
@@ -1158,10 +1151,13 @@ spec: ecmascript; urlPrefix: https://tc39.es/ecma262/multipage/
              </li>
            </ol>
         </li>
+        <li>
+          Return <var>p</var>.
+        </li>
       </ol>
     </p>
     </section>
-  </Section>
+  </section>
 </section>
 
 <section class='non-normative'>


### PR DESCRIPTION
Closes #229 by adding a media capabilities task source, and using it to resolve the promises created 
by `decodingInfo()` and `encodingInfo()`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/media-capabilities/pull/232.html" title="Last updated on Oct 4, 2024, 11:55 PM UTC (8cd3baf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/media-capabilities/232/6b47236...8cd3baf.html" title="Last updated on Oct 4, 2024, 11:55 PM UTC (8cd3baf)">Diff</a>