### PR TITLE
Update Makefile with lint and watch.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,22 @@
 LOCAL_BIKESHED := $(shell command -v bikeshed 2> /dev/null)
 
 index.html: index.bs
-#	./format.py $<
 ifndef LOCAL_BIKESHED
 	curl https://api.csswg.org/bikeshed/ -f -F file=@$< >$@;
 else
 	bikeshed spec
 endif
+
+ifdef LOCAL_BIKESHED
+.PHONY: lint watch
+
+lint: index.bs
+	bikeshed --print=plain --dry-run --force spec --line-numbers $<
+
+watch: index.bs
+	@echo 'Browse to file://${PWD}/index.html'
+	bikeshed --print=plain watch $<
+endif  # LOCAL_BIKESHED
+
+
+


### PR DESCRIPTION
This adds a couple of quality of life shortcuts for spec editing.

- `make lint` is a dry-run of bikeshed that reports any errors and warnings.
- `make watch` dynamically regenerates the spec when the source is updated.

