### PR TITLE
Add text about how to interpret width and height.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -414,6 +414,12 @@ spec: mimesniff; urlPrefix: https://mimesniff.spec.whatwg.org/#
       </p>
 
       <p>
+        If the {{scalabilityMode}} indicates that there are multiple spatial layers,
+        the {{width}} and {{height}} values in {{VideoConfiguration}}
+        correspond to the largest spatial layer that is encoded.
+      </p>
+
+      <p>
         If present, the <dfn for='VideoConfiguration' dict-member>spatialScalability</dfn>
         member represents the ability to do spatial prediction, that is,
         using frames of a resolution different than the current resolution as


### PR DESCRIPTION
Resolves #192.

Adds text about how to interpret width and height when `scalabilityMode` is set.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/media-capabilities/pull/236.html" title="Last updated on Oct 15, 2024, 9:33 PM UTC (54af3fc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/media-capabilities/236/e2c7d31...54af3fc.html" title="Last updated on Oct 15, 2024, 9:33 PM UTC (54af3fc)">Diff</a>