### PR TITLE
Make MediaCapabilitiesDecodingInfo and MediaCapabilitiesEncodingInfo configuration member required

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -675,13 +675,13 @@ spec: mimesniff; urlPrefix: https://mimesniff.spec.whatwg.org/#
     <xmp class='idl'>
       dictionary MediaCapabilitiesDecodingInfo : MediaCapabilitiesInfo {
         required MediaKeySystemAccess? keySystemAccess;
-        MediaDecodingConfiguration configuration;
+        required MediaDecodingConfiguration configuration;
       };
     </xmp>
 
     <xmp class='idl'>
       dictionary MediaCapabilitiesEncodingInfo : MediaCapabilitiesInfo {
-        MediaEncodingConfiguration configuration;
+        required MediaEncodingConfiguration configuration;
       };
     </xmp>
 


### PR DESCRIPTION
Fixes https://github.com/w3c/media-capabilities/issues/243


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/media-capabilities/pull/244.html" title="Last updated on May 13, 2025, 12:38 PM UTC (f651785)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/media-capabilities/244/f5a99e6...youennf:f651785.html" title="Last updated on May 13, 2025, 12:38 PM UTC (f651785)">Diff</a>