### PR TITLE
[Updated] Add a new webrtcCodec parameter to MediaCapabilitiesInfo

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -976,7 +976,7 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
             <li>
               If the user agent is able to decode the media represented by
               <var>configuration</var> and <var>configuration</var> has a type
-              of {{MediaDecodingType/webrtc}}, run the following substeps:
+              of {{MediaDecodingType/webrtc}}:
               <ol>
                 <li>Let <var>webrtc</var> be a
                 {{WebRTCMediaCapabilitiesInfo}} dictionary.</li>

--- a/index.bs
+++ b/index.bs
@@ -885,7 +885,7 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
               <var>configuration</var> and <var>configuration</var> has a type
               of {{MediaEncodingType/webrtc}}:
               <ol>
-                <li>Let <var>webrtc</var> be a
+                <li>Let |webrtc| be a
                 {{WebRTCMediaCapabilitiesInfo}} dictionary.</li>
                 <li>If audio is represented by <var>configuration</var>, set
                 <var>webrtc</var>'s {{WebRTCMediaCapabilitiesInfo/audio}}

--- a/index.bs
+++ b/index.bs
@@ -881,7 +881,7 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
               modules.
             </li>
             <li>
-              If the user agent is able to encode the media represented by
+              If the user agent can encode the media represented by
               <var>configuration</var> and <var>configuration</var> has a type
               of {{MediaEncodingType/webrtc}}:
               <ol>

--- a/index.bs
+++ b/index.bs
@@ -762,6 +762,7 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
         required boolean supported;
         required boolean smooth;
         required boolean powerEfficient;
+        RTCRtpCodecCapability webrtcCodec;
       };
     </pre>
 
@@ -783,7 +784,9 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
       for='MediaCapabilitiesInfo'>supported</dfn>, <dfn dict-member
       for='MediaCapabilitiesInfo'>smooth</dfn>, <dfn dict-member
       for='MediaCapabilitiesInfo'>powerEfficient</dfn> fields which are
-      booleans.
+      booleans, and an associated optional <dfn dict-member
+      for='MediaCapabilitiesInfo'>webrtcCodec</dfn> of type
+      {{RTCRtpCodecCapability}}.
     </p>
 
     <p class='note'>
@@ -793,6 +796,11 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
       configuration. It is worth noting that even when a device is not power
       constrained, high power usage has side effects such as increasing the
       temperature or the fans noise.
+    </p>
+
+    <p class='note'>
+      Authors can use {{MediaCapabilitiesInfo/webrtcCodec}} to set up their
+      preferred WebRTC codecs using the {{RTCRtpTransceiver/setCodecPreferences}} API.
     </p>
 
     <p>
@@ -868,6 +876,13 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
               modules.
             </li>
             <li>
+              If the user agent is able to encode the media represented by
+              <var>configuration</var> and <var>configuration</var> has a type
+              of {{MediaEncodingType/webrtc}}, set {{MediaCapabilitiesInfo/webrtcCodec}}
+              to the {{RTCRtpCodecCapability}} object representing the supported
+              codec configuration.
+            </li>
+            <li>
               Return <var>info</var>.
             </li>
           </ol>
@@ -940,6 +955,13 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
               power source in order to determine the decoding power
               efficiency unless the device's power source has side effects
               such as enabling different decoding modules.
+            </li>
+            <li>
+              If the user agent is able to decode the media represented by
+              <var>configuration</var> and <var>configuration</var> has a type
+              of {{MediaDecodingType/webrtc}}, set {{MediaCapabilitiesInfo/webrtcCodec}}
+              to the {{RTCRtpCodecCapability}} object representing the supported
+              codec configuration.
             </li>
             <li>
               Return <var>info</var>.

--- a/index.bs
+++ b/index.bs
@@ -762,7 +762,12 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
         required boolean supported;
         required boolean smooth;
         required boolean powerEfficient;
-        RTCRtpCodecCapability webrtcCodec;
+        WebRTCMediaCapabilitiesInfo webrtc;
+      };
+
+      dictionary WebRTCMediaCapabilitiesInfo {
+        RTCRtpCodecCapability audio;
+        RTCRtpCodecCapability video;
       };
     </pre>
 
@@ -785,8 +790,8 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
       for='MediaCapabilitiesInfo'>smooth</dfn>, <dfn dict-member
       for='MediaCapabilitiesInfo'>powerEfficient</dfn> fields which are
       booleans, and an associated optional <dfn dict-member
-      for='MediaCapabilitiesInfo'>webrtcCodec</dfn> of type
-      {{RTCRtpCodecCapability}}.
+      for='MediaCapabilitiesInfo'>webrtc</dfn> of type
+      {{WebRTCMediaCapabilitiesInfo}}.
     </p>
 
     <p class='note'>
@@ -799,7 +804,7 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
     </p>
 
     <p class='note'>
-      Authors can use {{MediaCapabilitiesInfo/webrtcCodec}} to set up their
+      Authors can use {{MediaCapabilitiesInfo/webrtc}} to set up their
       preferred WebRTC codecs using the {{RTCRtpTransceiver/setCodecPreferences}} API.
     </p>
 
@@ -878,9 +883,21 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
             <li>
               If the user agent is able to encode the media represented by
               <var>configuration</var> and <var>configuration</var> has a type
-              of {{MediaEncodingType/webrtc}}, set {{MediaCapabilitiesInfo/webrtcCodec}}
-              to the {{RTCRtpCodecCapability}} object representing the supported
-              codec configuration.
+              of {{MediaEncodingType/webrtc}}, run the following substeps:
+              <ol>
+                <li>Let <var>webrtc</var> be a
+                {{WebRTCMediaCapabilitiesInfo}} dictionary.</li>
+                <li>If audio is represented by <var>configuration</var>, set
+                <var>webrtc</var>'s {{WebRTCMediaCapabilitiesInfo/audio}}
+                to a {{RTCRtpCodecCapability}} dictionary representing the
+                supported audio configuration.</li>
+                <li>If video is represented by <var>configuration</var>, set
+                <var>webrtc</var>'s {{WebRTCMediaCapabilitiesInfo/video}}
+                to a {{RTCRtpCodecCapability}} dictionary representing the
+                supported video configuration.</li>
+                <li>Set <var>info</var>'s {{MediaCapabilitiesInfo/webrtc}}
+                to <var>webrtc</var>.</li>
+              </ol>
             </li>
             <li>
               Return <var>info</var>.
@@ -959,10 +976,21 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
             <li>
               If the user agent is able to decode the media represented by
               <var>configuration</var> and <var>configuration</var> has a type
-              of {{MediaDecodingType/webrtc}}, set {{MediaCapabilitiesInfo/webrtcCodec}}
-              to the {{RTCRtpCodecCapability}} object representing the supported
-              codec configuration.
-            </li>
+              of {{MediaDecodingType/webrtc}}, run the following substeps:
+              <ol>
+                <li>Let <var>webrtc</var> be a
+                {{WebRTCMediaCapabilitiesInfo}} dictionary.</li>
+                <li>If audio is represented by <var>configuration</var>, set
+                <var>webrtc</var>'s {{WebRTCMediaCapabilitiesInfo/audio}}
+                to a {{RTCRtpCodecCapability}} dictionary representing the
+                supported audio configuration.</li>
+                <li>If video is represented by <var>configuration</var>, set
+                <var>webrtc</var>'s {{WebRTCMediaCapabilitiesInfo/video}}
+                to a {{RTCRtpCodecCapability}} dictionary representing the
+                supported video configuration.</li>
+                <li>Set <var>info</var>'s {{MediaCapabilitiesInfo/webrtc}}
+                to <var>webrtc</var>.</li>
+              </ol>
             <li>
               Return <var>info</var>.
             </li>

--- a/index.bs
+++ b/index.bs
@@ -883,7 +883,7 @@ spec: secure-contexts; urlPrefix: https://www.w3.org/TR/secure-contexts/
             <li>
               If the user agent is able to encode the media represented by
               <var>configuration</var> and <var>configuration</var> has a type
-              of {{MediaEncodingType/webrtc}}, run the following substeps:
+              of {{MediaEncodingType/webrtc}}:
               <ol>
                 <li>Let <var>webrtc</var> be a
                 {{WebRTCMediaCapabilitiesInfo}} dictionary.</li>

--- a/index.bs
+++ b/index.bs
@@ -376,7 +376,7 @@ spec: mimesniff; urlPrefix: https://mimesniff.spec.whatwg.org/#
         using frames of a resolution different than the current resolution as
         dependencies. If absent, {{VideoConfiguration/spatialScalability}} defaults to
         <code>false</code>. If {{VideoConfiguration/spatialScalability}} is set to <code>true</code>,
-        the decoder can decode any {{VideoConfiguration/scalabilityMode}} 
+        the decoder can decode any {{VideoConfiguration/scalabilityMode}}
         that the encoder can encode for the configured codec. If {{VideoConfiguration/spatialScalability}}
         is set to <code>false</code>, the decoder cannot decode spatial scalability
         modes, but can decode all other {{VideoConfiguration/scalabilityMode}} values
@@ -819,32 +819,32 @@ spec: mimesniff; urlPrefix: https://mimesniff.spec.whatwg.org/#
             <code>true</code>.
           </li>
           <li>
-            If the user agent is able to encode the media represented by
+            If the user agent can encode the media represented by
             <var>configuration</var> at the indicated framerate, set
             {{MediaCapabilitiesInfo/smooth}} to <code>true</code>. Otherwise
             set it to <code>false</code>.
           </li>
           <li>
-            If the user agent is able to encode the media represented by
+            If the user agent can encode the media represented by
             <var>configuration</var> in a [=power efficient=] manner, set
             {{MediaCapabilitiesInfo/powerEfficient}} to <code>true</code>.
             Otherwise set it to <code>false</code>.
           </li>
           <li>
             If the user agent can encode the media represented by
-            <var>configuration</var> and <var>configuration</var> has a type
-            of {{MediaEncodingType/webrtc}}:
+            <var>configuration</var> and <var>configuration</var> has a
+            {{MediaEncodingConfiguration/type}} of {{MediaEncodingType/webrtc}}:
             <ol>
               <li>Let |webrtc| be a
               {{WebRTCMediaCapabilitiesInfo}} dictionary.</li>
-              <li>If audio is represented by <var>configuration</var>, set
-              <var>webrtc</var>'s {{WebRTCMediaCapabilitiesInfo/audio}}
-              to a {{RTCRtpCodec}} dictionary representing the
-              supported audio configuration.</li>
-              <li>If video is represented by <var>configuration</var>, set
-              <var>webrtc</var>'s {{WebRTCMediaCapabilitiesInfo/video}}
-              to a {{RTCRtpCodec}} dictionary representing the
-              supported video configuration.</li>
+              <li>If {{MediaConfiguration/audio}} is represented by
+              <var>configuration</var>, set <var>webrtc</var>'s
+              {{WebRTCMediaCapabilitiesInfo/audio}} to a {{RTCRtpCodec}} dictionary
+              representing the supported audio configuration.</li>
+              <li>If {{MediaConfiguration/video}} is represented by
+              <var>configuration</var>, set <var>webrtc</var>'s
+              {{WebRTCMediaCapabilitiesInfo/video}} to a {{RTCRtpCodec}} dictionary
+              representing the supported video configuration.</li>
               <li>Set <var>info</var>'s {{MediaCapabilitiesInfo/webrtc}}
               to <var>webrtc</var>.</li>
             </ol>
@@ -955,32 +955,32 @@ spec: mimesniff; urlPrefix: https://mimesniff.spec.whatwg.org/#
             Set {{MediaCapabilitiesInfo/supported}} to <code>true</code>.
           </li>
           <li>
-            If the user agent is able to decode the media represented by
+            If the user agent can decode the media represented by
             |configuration| at the indicated framerate
             without dropping frames, set {{MediaCapabilitiesInfo/smooth}}
             to <code>true</code>. Otherwise set it to <code>false</code>.
           </li>
           <li>
-            If the user agent is able to decode the media represented by
+            If the user agent can decode the media represented by
             |configuration| in a [=power efficient=]
             manner, set {{MediaCapabilitiesInfo/powerEfficient}} to
             <code>true</code>. Otherwise set it to <code>false</code>.
           </li>
           <li>
-            If the user agent is able to decode the media represented by
-            <var>configuration</var> and <var>configuration</var> has a type
-            of {{MediaDecodingType/webrtc}}:
+            If the user agent can decode the media represented by
+            <var>configuration</var> and <var>configuration</var> has a
+            {{MediaDecodingConfiguration/type}} of {{MediaDecodingType/webrtc}}:
             <ol>
               <li>Let <var>webrtc</var> be a
               {{WebRTCMediaCapabilitiesInfo}} dictionary.</li>
-              <li>If audio is represented by <var>configuration</var>, set
-              <var>webrtc</var>'s {{WebRTCMediaCapabilitiesInfo/audio}}
-              to a {{RTCRtpCodec}} dictionary representing the
-              supported audio configuration.</li>
-              <li>If video is represented by <var>configuration</var>, set
-              <var>webrtc</var>'s {{WebRTCMediaCapabilitiesInfo/video}}
-              to a {{RTCRtpCodec}} dictionary representing the
-              supported video configuration.</li>
+              <li>If {{MediaConfiguration/audio}} is represented by
+              <var>configuration</var>, set <var>webrtc</var>'s
+              {{WebRTCMediaCapabilitiesInfo/audio}} to a {{RTCRtpCodec}}
+              dictionary representing the supported audio configuration.</li>
+              <li>If {{MediaConfiguration/video}} is represented by
+              <var>configuration</var>, set <var>webrtc</var>'s
+              {{WebRTCMediaCapabilitiesInfo/video}} to a {{RTCRtpCodec}}
+              dictionary representing the supported video configuration.</li>
               <li>Set <var>info</var>'s {{MediaCapabilitiesInfo/webrtc}}
               to <var>webrtc</var>.</li>
             </ol>
@@ -1272,8 +1272,7 @@ spec: mimesniff; urlPrefix: https://mimesniff.spec.whatwg.org/#
         newly created {{TypeError}}.
       </li>
       <li>
-        If <code>configuration.keySystemConfiguration</code> [=map/exists=],
-        run the following substeps:
+        If <code>configuration.keySystemConfiguration</code> [=map/exists=]:
         <ol>
           <li>
             If the [=/global object=] is of type {{WorkerGlobalScope}},
@@ -1385,7 +1384,7 @@ spec: mimesniff; urlPrefix: https://mimesniff.spec.whatwg.org/#
         scalability, applications make use of external servers, such as
         selective forwarding units or conferencing bridges. These servers
         negotiate media parameters with participants, ensuring consistency
-        across senders and receivers. This is more scalable than negotiation 
+        across senders and receivers. This is more scalable than negotiation
         between user agents, which would require N * (N -1) negotiations.
         Typically senders encode with a single codec, and conferencing
         servers do not support transcoding, so a user agent cannot simply


### PR DESCRIPTION
This is a rebased version of PR #186 which is to close #185.

The type of the newly added dictionary is changed to `RTCRtpCodec` to fix Bikeshed linking errors.  Otherwise proposed edits from #186 are not yet applied.

This is not yet ready for review.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/media-capabilities/pull/250.html" title="Last updated on Nov 10, 2025, 5:58 AM UTC (e7e6eae)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/media-capabilities/250/b9d2f30...e7e6eae.html" title="Last updated on Nov 10, 2025, 5:58 AM UTC (e7e6eae)">Diff</a>