### PR TITLE
Adjust Makefile to target spec-generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ LOCAL_BIKESHED := $(shell command -v bikeshed 2> /dev/null)
 
 index.html: index.bs
 ifndef LOCAL_BIKESHED
-	curl https://api.csswg.org/bikeshed/ -f -F file=@$< >$@;
+	curl https://www.w3.org/publications/spec-generator/ -f -F type=bikeshed-spec -F file=@$< >$@;
 else
 	bikeshed spec
 endif

--- a/index.bs
+++ b/index.bs
@@ -575,7 +575,6 @@ spec: mimesniff; urlPrefix: https://mimesniff.spec.whatwg.org/#
         {{MediaDecodingConfiguration}} for types {{media-source}} and {{file}}.
       </p>
     </section>
-  </section>
 
   <section>
       <h4 id='mediacapabilitieskeysystemconfiguration'>
@@ -662,6 +661,7 @@ spec: mimesniff; urlPrefix: https://mimesniff.spec.whatwg.org/#
       as described in [[!ENCRYPTED-MEDIA-DRAFT]].
     </p>
   </section>
+  </section>
 
   <section>
     <h3 id='media-capabilities-info'>Media Capabilities Information</h3>
@@ -735,6 +735,7 @@ spec: mimesniff; urlPrefix: https://mimesniff.spec.whatwg.org/#
       is the encoding configuration properties used to generate the
       {{MediaCapabilitiesEncodingInfo}}.
     </p>
+  </section>
 
     <section>
       <h3 id='info-algorithms'>Algorithms</h3>


### PR DESCRIPTION
The former Bikeshed online service was deprecated in favor of Spec generator (which now supports Bikeshed specs), and no longer exists. This adjusts the Makefile accordingly.